### PR TITLE
speed up on patterns like "^foo" using memcmp

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -2,6 +2,7 @@
 #define GLOBALS_H
 
 #include "config.h"
+#include "defines.h"
 
 #include <regex.h>
 #include <stdint.h>
@@ -14,5 +15,7 @@ uint64_t loop, elim;
 uint8_t found, monitor, maxexectime;
 pthread_t lucky_thread;
 regex_t *regex;
+char prefix[BASE32_ONIONLEN];
+size_t prefix_size;
 
 #endif

--- a/src/thread.c
+++ b/src/thread.c
@@ -71,7 +71,13 @@ void *worker(void *params) { // life cycle of a cracking pthread
       base32_onion(onion, buf); // base32-encode SHA1 digest
       loop++;                   // keep track of our tries...
 
-      if(!regexec(regex, onion, 0, 0, 0)) { // check for a match
+      if(
+        regex
+        ?
+        (!regexec(regex, onion, 0, 0, 0))
+        :
+        (memcmp(prefix, onion, prefix_size) == 0)
+      ) { // check for a match
 
         // let our main thread know on which thread to wait
         lucky_thread = pthread_self();


### PR DESCRIPTION
Compare speed:

Before:

    $ timeout 10s ./shallot ^abcdefgh
    Caught SIGINT/SIGTERM after 19390861 tries - exiting.

Now:

    $ timeout 10s ./shallot ^abcdefgh
    Caught SIGINT/SIGTERM after 32956370 tries - exiting.